### PR TITLE
Added 'endstamp' option (timespan)

### DIFF
--- a/public/javascripts/timeline-setter.js
+++ b/public/javascripts/timeline-setter.js
@@ -644,6 +644,7 @@
     this.series = series;
     var card = _.clone(card);
     this.timestamp = card.timestamp;
+    this.endstamp = card.endstamp;
     this.attributes = card;
     this.attributes.topcolor = series.color;
 
@@ -675,9 +676,18 @@
     // is currently selected via `window.location.hash` it's activated.
     render : function(e){
       if (!e.type === "render") return;
+      var width = null;
+      var alpha = null;
       this.offset = this.series.timeline.bounds.project(this.timestamp, 100);
+      if (this.endstamp) {
+      	this.endOffset = this.series.timeline.bounds.project(this.endstamp, 100);
+      	this.endOffset -= this.offset;
+      	width = this.endOffset + "%";
+      	alpha = .5;
+      	console.log(this.endstamp, width);
+      }
       var html = this.ntemplate(this.attributes);
-      this.notch = $(html).css({"left": this.offset + "%"});
+      this.notch = $(html).css({"left": this.offset + "%", width: width, opacity: alpha});
       $(".TS-notchbar").append(this.notch);
       this.notch.click(this.activate);
       if (history.get() === this.id) this.activate();


### PR DESCRIPTION
Hey. I am Robert Huttinger. I work with Thomas Wilburn at CQ.

We are working on a backend for a non Ruby instantiation of the timeline tool. As part of our implementation we added the ability to add an 'endstamp' in the JSON to create a span of time.

If the 'endstamp' exists, then the 'TS-notch' is set to a width that spans from the 'timestamp', to the 'endstamp', and the opacity is set to 0.7. If it does not exist, it behaves normally.

This is a simple fix but we wanted to share with the community, as you shared this great tool. As we continue working hopefully we can contribute more!

Robert
