### PR TITLE
Fix for 'endstamp' overflow

### DIFF
--- a/public/javascripts/timeline-setter.js
+++ b/public/javascripts/timeline-setter.js
@@ -644,6 +644,7 @@
     this.series = series;
     var card = _.clone(card);
     this.timestamp = card.timestamp;
+    this.endstamp = card.endstamp;
     this.attributes = card;
     this.attributes.topcolor = series.color;
 
@@ -675,9 +676,18 @@
     // is currently selected via `window.location.hash` it's activated.
     render : function(e){
       if (!e.type === "render") return;
+      var width = null;
+      var alpha = null;
       this.offset = this.series.timeline.bounds.project(this.timestamp, 100);
+      if (this.endstamp) {
+      	this.endOffset = this.series.timeline.bounds.project(this.endstamp, 100);
+      	this.endOffset -= this.offset;
+      	width = this.endOffset + "%";
+      	alpha = .5;
+      	console.log(this.endstamp, width);
+      }
       var html = this.ntemplate(this.attributes);
-      this.notch = $(html).css({"left": this.offset + "%"});
+      this.notch = $(html).css({"left": this.offset + "%", width: width, opacity: alpha});
       $(".TS-notchbar").append(this.notch);
       this.notch.click(this.activate);
       if (history.get() === this.id) this.activate();

--- a/public/javascripts/timeline-setter.js
+++ b/public/javascripts/timeline-setter.js
@@ -633,7 +633,9 @@
   // Proxy to underscore for `min` and `max`.
   _(["min", "max"]).each(function(key){
     Series.prototype[key] = function() {
-      return _[key].call(_, this.cards, this._comparator).get("timestamp");
+      var temptimeStamp = _[key].call(_, this.cards, this._comparator).get("timestamp");
+      var tempEndStamp = _[key].call(_, this.cards, this._comparator).get("endstamp");
+      return (tempEndStamp && (tempEndStamp > temptimeStamp)) ? tempEndStamp : temptimeStamp;
     };
   });
 


### PR DESCRIPTION
After adding the ability to add an 'endstamp' to allow for representing a timeline entry as a span of time, I discovered we had omitted the overflow issue. Now the existing methods account for the 'endstamp' in the calculations for timeline overall width and scroll.

Of Note:
adding and 'endstamp' 'changes' the UI in one respect, the card display only shows the display_date, or first date. We changed out internal (PHP) render to check for the existence of an 'endstamp', and render accordingly.

without: Jun. 02, 2011
with: Jun. 02, 2011 - Aug. 25, 2012
