### PR TITLE
Use Chronic for time parsing

### DIFF
--- a/lib/timeline_setter.rb
+++ b/lib/timeline_setter.rb
@@ -5,10 +5,12 @@ end
 
 require 'date'
 require 'time'
+require 'chronic'
 require 'erb'
 require 'table_fu'
 require 'json'
 require 'kompress'
+
 
 require "#{TimelineSetter::ROOT}/lib/timeline_setter/version"
 require "#{TimelineSetter::ROOT}/lib/timeline_setter/parser"

--- a/lib/timeline_setter/timeline.rb
+++ b/lib/timeline_setter/timeline.rb
@@ -11,10 +11,10 @@ module TimelineSetter
     # Convert human dates to timestamps, sort the hash by timestamp, and
     # convert the events hash to JSON to stick into our HTML.
     def to_json
-      @events.each {|r| r[:timestamp] = Time.parse(r[:date]).to_i * 1000 }
+      @events.each {|r| r[:timestamp] = Chronic.parse(r[:date]).to_i * 1000 }
       @events.to_json
     end
-    
+
     def config_json
       {
         "interval"  => "#{@interval}",
@@ -44,7 +44,7 @@ module TimelineSetter
       @js << File.open("#{TimelineSetter::ROOT}/public/javascripts/timeline-setter.min.js", 'r').read
       @timeline = tmpl("timeline-min.erb")
     end
-    
+
     def tmpl(tmpl_file)
       ERB.new(File.open("#{TimelineSetter::ROOT}/templates/#{tmpl_file}").read).result(binding)
     end

--- a/timeline_setter.gemspec
+++ b/timeline_setter.gemspec
@@ -93,12 +93,14 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<table_fu>, [">= 0"])
       s.add_runtime_dependency(%q<kompress>, [">= 0.0.2"])
       s.add_runtime_dependency(%q<jammit>, [">= 0"])
+      s.add_runtime_dependency(%q<chronic>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 2.0.0"])
     else
       s.add_dependency(%q<json>, [">= 0"])
       s.add_dependency(%q<table_fu>, [">= 0"])
       s.add_dependency(%q<kompress>, [">= 0.0.2"])
       s.add_dependency(%q<jammit>, [">= 0"])
+      s.add_dependency(%q<chronic>, [">= 0"])
       s.add_dependency(%q<rspec>, [">= 2.0.0"])
     end
   else
@@ -106,7 +108,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<table_fu>, [">= 0"])
     s.add_dependency(%q<kompress>, [">= 0.0.2"])
     s.add_dependency(%q<jammit>, [">= 0"])
+    s.add_dependency(%q<chronic>, [">= 0"])
     s.add_dependency(%q<rspec>, [">= 2.0.0"])
   end
 end
-


### PR DESCRIPTION
Default Ruby `Time.parse` falls a bit short for some time/date formats. [Chronic](http://chronic.rubyforge.org/) seems to improve that.

Thanks!
