### PR TITLE
Add utf-8 support and fix typo in config

### DIFF
--- a/config/assets.yml
+++ b/config/assets.yml
@@ -1,4 +1,4 @@
-embed_assets :on
+embed_assets: on
 template_function: _.template
 
 javascripts:

--- a/templates/timeline.erb
+++ b/templates/timeline.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
     <link href="stylesheets/timeline-setter.css" rel="stylesheet" />
     <script src="javascripts/vendor/jquery-min.js"></script>
     <script src="javascripts/vendor/underscore-min.js"></script>


### PR DESCRIPTION
When playing around with the tool and tweaking it into spanish I realized that the config file had a typo and that the main html template was not set to handle utf-8 by default.

Not really mind blowing changes but I hope you find them useful
